### PR TITLE
Refactor: 홈 화면 리팩토링 및 스크롤 버튼 수정

### DIFF
--- a/src/components/EditorPick.tsx
+++ b/src/components/EditorPick.tsx
@@ -235,14 +235,28 @@ const EditorPick = () => {
   };
 
   /** 스크롤 (왼, 오) 버튼 클릭 */
-  const handleButtonNext = (direction: "right" | "left") => {
+  const onNext = (direction: "right" | "left") => {
     const directionCase = {
       right: () => {
-        setSlidPosition((prev) => (prev -= activePage === 2 ? 480 : 960));
+        setSlidPosition((prev) => {
+          if (activePage === 1) {
+            prev -= 480;
+          } else {
+            prev -= 960;
+          }
+          return prev;
+        });
         setActivePage((prev) => prev + 1);
       },
       left: () => {
-        setSlidPosition((prev) => (prev += activePage === 1 ? 480 : 960));
+        setSlidPosition((prev) => {
+          if (activePage === 2) {
+            prev += 480;
+          } else {
+            prev += 960;
+          }
+          return prev;
+        });
         setActivePage((prev) => prev - 1);
       },
     };
@@ -256,14 +270,14 @@ const EditorPick = () => {
         {/* 왼쪽 오른쪽 버튼 구현부 */}
         {/* 스크롤 버튼이 2 <= activePage <= 9 일 때만 화면에 표시 */}
         {activePage >= 2 && (
-          <div onClick={() => handleButtonNext("left")}>
-            <LeftButton $left="30px" $top="50%" />
-          </div>
+          <LeftButton $left="30px" $top="50%" onClick={() => onNext("left")} />
         )}
         {activePage <= 9 && (
-          <div onClick={(e) => handleButtonNext("right")}>
-            <RightButton $right="30px" $top="50%" />
-          </div>
+          <RightButton
+            $right="30px"
+            $top="50%"
+            onClick={() => onNext("right")}
+          />
         )}
 
         {/* 슬라이드 구현부 */}
@@ -299,7 +313,7 @@ const SlideContainer: React.FC<SlideProps> = ({ children, slidePosition }) => {
   return <WrapSlide $slidePosition={slidePosition}>{children}</WrapSlide>;
 };
 
-const SlideInner = () => {
+const SlideInner = React.memo(() => {
   return (
     <>
       {/* 1페이지 */}
@@ -421,7 +435,7 @@ const SlideInner = () => {
       </li>
     </>
   );
-};
+});
 export default EditorPick;
 
 const DefaultUl = styled.ul`

--- a/src/components/ScrollButton.tsx
+++ b/src/components/ScrollButton.tsx
@@ -5,15 +5,12 @@ interface ButtonProps {
   $top: string;
   $left?: string;
   $right?: string;
+  onClick: (e: React.MouseEvent<HTMLSpanElement>) => void;
 }
 
-interface ButtonImageProps {
-  $backgroundPosition: string;
-}
-
-export const LeftButton = ({ $top, $left }: ButtonProps) => {
+export const LeftButton = ({ $top, $left, onClick }: ButtonProps) => {
   return (
-    <ButtonContainer $top={$top} $left={$left}>
+    <ButtonContainer $top={$top} $left={$left} onClick={onClick}>
       <ButtonImage $backgroundPosition="-167px -175px">
         이전 에디터픽 보기
       </ButtonImage>
@@ -21,11 +18,11 @@ export const LeftButton = ({ $top, $left }: ButtonProps) => {
   );
 };
 
-export const RightButton = ({ $top, $right }: ButtonProps) => {
+export const RightButton = ({ $top, $right, onClick }: ButtonProps) => {
   return (
-    <ButtonContainer $top={$top} $right={$right}>
+    <ButtonContainer $top={$top} $right={$right} onClick={onClick}>
       <ButtonImage $backgroundPosition="-269px -175px">
-        이전 에디터픽 보기
+        다음 에디터픽 보기
       </ButtonImage>
     </ButtonContainer>
   );
@@ -46,7 +43,7 @@ const Button = styled.button`
   cursor: pointer;
 `;
 
-const ButtonImage = styled(Button)<ButtonImageProps>`
+const ButtonImage = styled(Button)<{ $backgroundPosition: string }>`
   background: url("https://t1.daumcdn.net/brunch9/static/images/pc/ico_brunch_v9_230901.png")
     no-repeat;
   background-position: ${(props) => props.$backgroundPosition};

--- a/src/components/Writers.tsx
+++ b/src/components/Writers.tsx
@@ -313,7 +313,7 @@ interface ProfileProps {
 }
 
 interface ButtonProps {
-  fontSize: string;
+  $fontSize: string;
   $padding: string;
   $isActive?: boolean;
 }
@@ -343,7 +343,7 @@ const Writers = () => {
         {fakeDataList.category.map((category, buttonId) => (
           <li key={category.id}>
             <Button
-              fontSize="15px"
+              $fontSize="15px"
               $padding="7px 16px 6px"
               $isActive={activeButton === buttonId}
               onClick={() => handleCategoryClick(buttonId)}
@@ -371,10 +371,10 @@ const Writers = () => {
               <Description>{data.profile_desc}</Description>
               {/* 한 프로필 당 카테고리 리스트 */}
               <UL>
-                {data.profile_categories.map((category) => (
+                {data.profile_categories.slice(0, 2).map((category) => (
                   <li key={category.id}>
                     <Button
-                      fontSize="12px"
+                      $fontSize="12px"
                       $padding="4px 10px"
                       $isActive={false}
                       onClick={() => openWindow(category.name)}
@@ -383,6 +383,9 @@ const Writers = () => {
                     </Button>
                   </li>
                 ))}
+                <li>
+                  <MoreButton>더보기</MoreButton>
+                </li>
               </UL>
             </WriterItem>
           ))}
@@ -525,10 +528,10 @@ const UL = styled.ul`
 
 const Button = styled.button<ButtonProps>`
   font-family: "Noto Sans Light", sans-serif;
-  font-size: ${(props) => props.fontSize};
+  font-size: ${(props) => props.$fontSize};
   letter-spacing: -1px;
   line-height: 18px;
-  color: #959595;
+  color: ${(props) => (props.$isActive ? "#00c6be" : "#959595")};
 
   border: ${(props) => (props.$isActive ? "#00c6be" : "#ddd")} 1px solid;
 
@@ -538,6 +541,23 @@ const Button = styled.button<ButtonProps>`
 
   /*padding: 4px 10px;*/
   padding: ${(props) => props.$padding};
+
+  cursor: pointer;
+
+  display: block;
+`;
+
+const MoreButton = styled.button`
+  text-indent: -9999px;
+
+  width: 35px;
+  height: 28px;
+
+  background: url("https://t1.daumcdn.net/brunch9/static/images/pc/ico_brunch_v9_230901.png")
+    no-repeat;
+  background-position: -280px -70px;
+
+  border: none;
 
   cursor: pointer;
 


### PR DESCRIPTION
#  🔥 Pull request
### ✅ 주요 기능 
- onNext 성연님 코드 참고해서 수정
- scrollButton.tsx 의 버튼 props에 onClick 추가
- React.memo()로 렌더링 최적화

### 📑 기능 부연 설명
- **scrollbutton.tsx의 LeftButton, RightButton 컴포넌트 최종 완성되었으니 사용하시면 됩니다!**
  - LeftButton의 props: $left, $top, onClick
  - RightButton의 props: $right, $top, onClick
  - ex) 
![image](https://github.com/BrunchStory/Web/assets/92720304/eac27ab4-8094-4c6e-bba0-cef4fe682e4a)

- **Writers.tsx (추천작가) 에 한 프로필 당 키워드가 3개 이상이라면 2개까지만 보여주고 나머지는 더보기(...)버튼으로 대체**
- **EditorPick.tsx의 `<SlideInner/>`에 React.memo()로 렌더링 최적화**


### 🖼️ 스크린샷
![image](https://github.com/BrunchStory/Web/assets/92720304/5b841c28-75a3-4d8a-ac00-910c130370cb)


### 😂 보완할 점

