### PR TITLE
Feat: 요일별 api 작성

### DIFF
--- a/src/api/week.api.ts
+++ b/src/api/week.api.ts
@@ -1,0 +1,8 @@
+import { IWeek } from "../models/week.model";
+import { customAxios } from "./customAxios";
+
+export const getWeekList = async () => {
+  const response = await customAxios.get<IWeek>("/posts/weeks");
+
+  return response.data;
+};

--- a/src/hooks/useWeek.ts
+++ b/src/hooks/useWeek.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { IWeek } from "../models/week.model";
+import { getWeekList } from "../api/week.api";
+
+export const useWeek = () => {
+  const [weeks, setWeeks] = useState([]);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    const getList = async () => {
+      setLoading(true);
+      try {
+        const res: any = await getWeekList();
+
+        setWeeks(res);
+        console.log(res);
+      } catch (e) {
+        setError("erro 발생");
+        throw e;
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    getList();
+  }, []);
+
+  return { weeks, error, loading };
+};

--- a/src/models/week.model.ts
+++ b/src/models/week.model.ts
@@ -1,0 +1,9 @@
+export interface IWeek {
+  DONATION_TOTAL_AMOUNT: number;
+  PUBLISH_TIME: string;
+  id: number;
+  text: string;
+  title: string;
+  writer: string;
+  img?: string;
+}


### PR DESCRIPTION
#  🔥 Pull request
### ✅ 주요 기능 
- 요일별 list get api를 주영님이 만드신 예를 보고 작성했습니다.

### 📑 기능 부연 설명
- `import { useEffect, useState } from "react";
import { IWeek } from "../models/week.model";
import { getWeekList } from "../api/week.api";

export const useWeek = () => {
  const [weeks, setWeeks] = useState([]);
  const [error, setError] = useState("");
  const [loading, setLoading] = useState<boolean>(false);

  useEffect(() => {
    const getList = async () => {
      setLoading(true);
      try {
        const res: any = await getWeekList();

        setWeeks(res);
        console.log(res);
      } catch (e) {
        setError("erro 발생");
        throw e;
      } finally {
        setLoading(false);
      }
    };

    getList();
  }, []);

  return { weeks, error, loading };
};
`
이런식으로 loading, error, weeks 이렇게 3가지의 값을 반환하도록 작성하였습니다.
### 🖼️ 스크린샷
- 스크린 샷 혹은 동영상을 첨부해주세요

### 😂 보완할 점
- 현재 실행 시 prowy 오류가 뜨는 것으로 보아 서버 또는 저의 문제가 있는 것으로 보입니다.
- 최대한 빨리 수정하겠습니다.
